### PR TITLE
Feature/cleanup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# IDE sessions
+.idea

--- a/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
+++ b/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
@@ -28,7 +28,7 @@ def cleanup(dir_path, retention_days):
 
 def handle_path(path, retention_days):
     if os.path.islink(path):
-        print(f"Ignoring file - file is a symbolic link: {path}")
+        print(f"Ignoring path - object is a symbolic link: {path}")
         return
 
     if os.path.isdir(path):

--- a/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
+++ b/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
@@ -16,6 +16,9 @@ def cleanup(dir_path, retention_days):
         entry_path = os.path.join(dir_path, entry)
         handle_path(entry_path, retention_days)
 
+    if not os.listdir(dir_path):
+        handle_directory_removal(dir_path)
+
     print(f"Cleaned up {dir_path}")
 
 

--- a/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
+++ b/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
@@ -1,6 +1,5 @@
 import argparse
-import errno, os, stat, sys
-import shutil
+import os
 from datetime import datetime
 
 def cleanup(dir_path, retention_days):
@@ -21,7 +20,7 @@ def cleanup(dir_path, retention_days):
         handle_path(entry_path, retention_days)
 
     if not os.listdir(dir_path):
-        handle_directory_removal(dir_path)
+        handle_directory_removal(dir_path, retention_days)
 
     print(f"Successfully cleaned up directory {dir_path} - with retention days: {retention_days}")
 
@@ -37,63 +36,63 @@ def handle_path(path, retention_days):
         handle_file_removal(path, retention_days)
 
 
-def handle_directory(directory, retention_days):
-    contents = os.listdir(directory)
-    if not contents:
-        handle_directory_removal(directory)
+def handle_directory(dir_path, retention_days):
+    if is_dir_empty(dir_path):
+        handle_directory_removal(dir_path, retention_days)
         return
 
-    for entry in contents:
-        entry_path = os.path.join(directory, entry)
+    for entry in os.listdir(dir_path):
+        entry_path = os.path.join(dir_path, entry)
         handle_path(entry_path, retention_days)
 
-    if not os.listdir(directory):
-        handle_directory_removal(directory)
+    if is_dir_empty(dir_path):
+        handle_directory_removal(dir_path, retention_days)
+
 
 def handle_file_removal(file_path, retention_days):
-    last_modified = datetime.fromtimestamp(os.path.getmtime(file_path))
-    last_modified_days = (datetime.now() - last_modified).days
-    if last_modified_days <= retention_days:
+    after_retention, last_modified_days = is_after_retention_period(file_path, retention_days)
+
+    if not after_retention:
         print(f"File unchanged {file_path} - last modified {last_modified_days} days")
         return
 
     try:
         os.remove(file_path)
         print(f"Removed file {file_path} - last modified {last_modified_days} days")
+    except OSError as e:
+        print(f"Could not remove file {file_path}: {e}")
 
-    except OSError:
-        try:
-            remove_readonly(os.remove, file_path, sys.exc_info())
-            print(f"Removed readonly file {file_path} - last modified {last_modified_days} days")
 
-        except OSError as e:
-            print(f"Could not remove file {file_path}: {e}")
-            return
+def handle_directory_removal(dir_path, retention_days):
+    after_retention, last_modified_days = is_after_retention_period(dir_path, retention_days)
 
-def handle_directory_removal(path):
-    if not os.path.isdir(path):
-        print(f"Path is not a directory: {path}")
+    if not after_retention:
+        print(f"Directory unchanged {dir_path} - last modified {last_modified_days} days")
         return
 
     try:
-        shutil.rmtree(path, ignore_errors=False, onerror=remove_readonly)
-        print(f"Removed directory {path}")
+        os.rmdir(dir_path)
+        print(f"Removed directory {dir_path} - last modified {last_modified_days} days")
     except OSError as e:
-        print(f"Could not remove directory or file {path}: {e}")
+        print(f"Could not remove directory or file {dir_path}: {e}")
 
-def remove_readonly(func, path, exc):
-    # onerror callback for shutil.rmtree: whenever a delete fails partway through the tree, instead of aborting the whole rmtree.
-    excvalue = exc[1]
-    if func in (os.rmdir, os.remove, os.unlink) and excvalue.errno == errno.EACCES:
-      # Windows marks some OneDrive files read-only, which makes rmdir/remove raise
-      # "access denied" (EACCES). Clearing the attribute and retrying fixes that case.
-      os.chmod(path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777
-      func(path)
+
+def is_after_retention_period(path, retention_days):
+    last_modified = datetime.fromtimestamp(os.path.getmtime(path))
+    last_modified_days = (datetime.now() - last_modified).days
+
+    if last_modified_days > retention_days:
+        return True, last_modified_days
     else:
-      # Not a read-only issue (e.g. an ACL delete-deny) - re-raise the original exception.
-      # Works because rmtree calls onerror() from inside its own except block, so the
-      # exception context is still live for a bare `raise` to pick up.
-        raise
+        return False, last_modified_days
+
+
+def is_dir_empty(dir_path):
+    if os.listdir(dir_path):
+        return False
+    else:
+        return True
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Clean up old files in target folder (e.g: in XNAT cache, temp and deleted folders)')

--- a/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
+++ b/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
@@ -1,0 +1,78 @@
+import argparse
+import errno, os, stat
+import shutil
+from datetime import datetime
+
+def cleanup(dir_path, retention_days):
+    if not os.path.exists(dir_path):
+        print(f"Path does not exist: {dir_path}")
+        return
+
+    if not os.path.isdir(dir_path):
+        print(f"Path is not a directory: {dir_path}")
+        return
+
+    for entry in os.listdir(dir_path):
+        entry_path = os.path.join(dir_path, entry)
+        handle_path(entry_path, retention_days)
+
+    print(f"Cleaned up {dir_path}")
+
+
+def handle_path(path, retention_days):
+    if os.path.isdir(path):
+        handle_directory(path, retention_days)
+    elif os.path.isfile(path):
+        handle_file_removal(path, retention_days)
+
+
+def handle_directory(directory, retention_days):
+    contents = os.listdir(directory)
+    if not contents:
+        handle_directory_removal(directory)
+        return
+
+    for entry in contents:
+        entry_path = os.path.join(directory, entry)
+        handle_path(entry_path, retention_days)
+
+    if not os.listdir(directory):
+        handle_directory_removal(directory)
+
+def handle_file_removal(file_path, retention_days):
+    last_modified = datetime.fromtimestamp(os.path.getmtime(file_path))
+    last_modified_days = (datetime.now() - last_modified).days
+    if last_modified_days > retention_days:
+        os.remove(file_path)
+        print(f"Removed file {file_path} - last modified {last_modified_days} days")
+
+def handle_directory_removal(path):
+    try:
+        shutil.rmtree(path, ignore_errors=False, onerror=remove_readonly)
+        print(f"Removed directory {path}")
+    except OSError as e:
+        print(f"Could not remove directory or file {path}: {e}")
+
+def remove_readonly(func, path, exc):
+    # onerror callback for shutil.rmtree: whenever a delete fails partway through the tree, instead of aborting the whole rmtree.
+    excvalue = exc[1]
+    if func in (os.rmdir, os.remove) and excvalue.errno == errno.EACCES:
+      # Windows marks some OneDrive files read-only, which makes rmdir/remove raise
+      # "access denied" (EACCES). Clearing the attribute and retrying fixes that case.
+      os.chmod(path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777
+      func(path)
+    else:
+      # Not a read-only issue (e.g. an ACL delete-deny) - re-raise the original exception.
+      # Works because rmtree calls onerror() from inside its own except block, so the
+      # exception context is still live for a bare `raise` to pick up.
+      raise
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Clean up old files in target folder (e.g: in XNAT cache, temp and deleted folders)')
+    parser.add_argument('--dir_path', type=str, required=True,
+                        help='Path to directory to clean up')
+    parser.add_argument('--retention_days', type=int, default=90,
+                        help='Retention period in days, every file and empty directory older than this value will be cleaned up (default: 90)')
+    args = parser.parse_args()
+
+    cleanup(args.dir_path, args.retention_days)

--- a/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
+++ b/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
@@ -5,11 +5,15 @@ from datetime import datetime
 
 def cleanup(dir_path, retention_days):
     if not os.path.exists(dir_path):
-        print(f"Path does not exist: {dir_path}")
+        print(f"Stopping cleanup - path does not exist: {dir_path}")
         return
 
     if not os.path.isdir(dir_path):
-        print(f"Path is not a directory: {dir_path}")
+        print(f"Stopping cleanup - path is not a directory: {dir_path}")
+        return
+
+    if os.path.islink(dir_path):
+        print(f"Stopping cleanup - path is a symbolic link, : {dir_path}")
         return
 
     for entry in os.listdir(dir_path):
@@ -19,10 +23,14 @@ def cleanup(dir_path, retention_days):
     if not os.listdir(dir_path):
         handle_directory_removal(dir_path)
 
-    print(f"Cleaned up {dir_path}")
+    print(f"Successfully cleaned up directory {dir_path} - with retention days: {retention_days}")
 
 
 def handle_path(path, retention_days):
+    if os.path.islink(path):
+        print(f"Ignoring file - file is a symbolic link: {path}")
+        return
+
     if os.path.isdir(path):
         handle_directory(path, retention_days)
     elif os.path.isfile(path):
@@ -46,20 +54,27 @@ def handle_file_removal(file_path, retention_days):
     last_modified = datetime.fromtimestamp(os.path.getmtime(file_path))
     last_modified_days = (datetime.now() - last_modified).days
     if last_modified_days <= retention_days:
+        print(f"File unchanged {file_path} - last modified {last_modified_days} days")
         return
 
     try:
         os.remove(file_path)
+        print(f"Removed file {file_path} - last modified {last_modified_days} days")
+
     except OSError:
         try:
             remove_readonly(os.remove, file_path, sys.exc_info())
+            print(f"Removed readonly file {file_path} - last modified {last_modified_days} days")
+
         except OSError as e:
             print(f"Could not remove file {file_path}: {e}")
             return
 
-    print(f"Removed file {file_path} - last modified {last_modified_days} days")
-
 def handle_directory_removal(path):
+    if not os.path.isdir(path):
+        print(f"Path is not a directory: {path}")
+        return
+
     try:
         shutil.rmtree(path, ignore_errors=False, onerror=remove_readonly)
         print(f"Removed directory {path}")
@@ -78,7 +93,7 @@ def remove_readonly(func, path, exc):
       # Not a read-only issue (e.g. an ACL delete-deny) - re-raise the original exception.
       # Works because rmtree calls onerror() from inside its own except block, so the
       # exception context is still live for a bare `raise` to pick up.
-      raise
+        raise
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Clean up old files in target folder (e.g: in XNAT cache, temp and deleted folders)')

--- a/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
+++ b/src/xnat_maintenance_monitoring_scripts/folder_cleanup.py
@@ -1,5 +1,5 @@
 import argparse
-import errno, os, stat
+import errno, os, stat, sys
 import shutil
 from datetime import datetime
 
@@ -42,9 +42,19 @@ def handle_directory(directory, retention_days):
 def handle_file_removal(file_path, retention_days):
     last_modified = datetime.fromtimestamp(os.path.getmtime(file_path))
     last_modified_days = (datetime.now() - last_modified).days
-    if last_modified_days > retention_days:
+    if last_modified_days <= retention_days:
+        return
+
+    try:
         os.remove(file_path)
-        print(f"Removed file {file_path} - last modified {last_modified_days} days")
+    except OSError:
+        try:
+            remove_readonly(os.remove, file_path, sys.exc_info())
+        except OSError as e:
+            print(f"Could not remove file {file_path}: {e}")
+            return
+
+    print(f"Removed file {file_path} - last modified {last_modified_days} days")
 
 def handle_directory_removal(path):
     try:
@@ -56,7 +66,7 @@ def handle_directory_removal(path):
 def remove_readonly(func, path, exc):
     # onerror callback for shutil.rmtree: whenever a delete fails partway through the tree, instead of aborting the whole rmtree.
     excvalue = exc[1]
-    if func in (os.rmdir, os.remove) and excvalue.errno == errno.EACCES:
+    if func in (os.rmdir, os.remove, os.unlink) and excvalue.errno == errno.EACCES:
       # Windows marks some OneDrive files read-only, which makes rmdir/remove raise
       # "access denied" (EACCES). Clearing the attribute and retrying fixes that case.
       os.chmod(path, stat.S_IRWXU| stat.S_IRWXG| stat.S_IRWXO) # 0777

--- a/tests/test_stub.py
+++ b/tests/test_stub.py
@@ -1,5 +1,0 @@
-import xnat_maintenance_monitoring_scripts.disk_usages
-import xnat_maintenance_monitoring_scripts.users_per_project
-
-def test_pass():
-    assert True

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -1,7 +1,10 @@
+import errno
 import os
 import stat
 from datetime import datetime, timedelta
 from unittest.mock import patch
+
+import pytest
 
 from xnat_maintenance_monitoring_scripts import folder_cleanup
 
@@ -204,6 +207,17 @@ def test_handle_directory_removal_unrecoverable_error(mock_rmtree, tmp_path, cap
     )
     assert directory.exists()
     assert "Could not remove directory or file" in capsys.readouterr().out
+
+
+def test_remove_readonly_eacces_retries(tmp_path):
+    file_path = tmp_path / "readonly.txt"
+    file_path.write_text("content")
+    os.chmod(file_path, stat.S_IREAD)
+    exc = (OSError, OSError(errno.EACCES, "Access denied"), None)
+
+    folder_cleanup.remove_readonly(os.remove, str(file_path), exc)
+
+    assert not file_path.exists()
 
 
 def _age(path, days_old):

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -29,16 +29,16 @@ def test_cleanup_path_is_symlink(mock_islink, tmp_path, capsys):
     mock_islink.return_value = True
     directory = tmp_path / "link_dir"
     directory.mkdir()
-    (directory / "file.txt").write_text("content")
 
     folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
 
-    assert (directory / "file.txt").exists()
     assert "path is a symbolic link" in capsys.readouterr().out
+    assert directory.exists()
 
 def test_cleanup_removes_old_file_and_empty_directory(tmp_path):
     directory = tmp_path / "dir"
     directory.mkdir()
+
     old_file = directory / "old.txt"
     old_file.write_text("old")
     _age(old_file, RETENTION_DAYS + 10)
@@ -51,6 +51,7 @@ def test_cleanup_removes_old_file_and_empty_directory(tmp_path):
 def test_cleanup_keeps_directory_with_fresh_file(tmp_path):
     directory = tmp_path / "dir"
     directory.mkdir()
+
     fresh_file = directory / "fresh.txt"
     fresh_file.write_text("fresh")
     _age(fresh_file, RETENTION_DAYS - 10)
@@ -60,31 +61,24 @@ def test_cleanup_keeps_directory_with_fresh_file(tmp_path):
     assert fresh_file.exists()
     assert directory.exists()
 
-def test_cleanup_nested_directories_recursively_cleaned(tmp_path):
+def test_cleanup_nested_directories_recursively_cleaned(tmp_path, capsys):
     directory = tmp_path / "dir"
+
     subdir = directory / "subdir"
     subdir.mkdir(parents=True)
+
     old_file = subdir / "old.txt"
     old_file.write_text("old")
     _age(old_file, RETENTION_DAYS + 10)
 
     folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+    out = capsys.readouterr().out
 
     assert not old_file.exists()
     assert not subdir.exists()
     assert not directory.exists()
-
-def test_cleanup_prints_success_message(tmp_path, capsys):
-    directory = tmp_path / "dir"
-    directory.mkdir()
-    fresh_file = directory / "fresh.txt"
-    fresh_file.write_text("fresh")
-    _age(fresh_file, RETENTION_DAYS - 10)
-
-    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
-
-    out = capsys.readouterr().out
     assert f"Successfully cleaned up directory {directory}" in out
+
 
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -4,8 +4,6 @@ import stat
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-import pytest
-
 from xnat_maintenance_monitoring_scripts import folder_cleanup
 
 RETENTION_DAYS = 90
@@ -23,7 +21,6 @@ def test_handle_path_dir(mock_isdir, mock_isfile, mock_handle_directory, mock_ha
     mock_handle_directory.assert_called_once_with("some/dir", 90)
     mock_handle_file_removal.assert_not_called()
 
-
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
 @patch("os.path.isfile")
@@ -36,7 +33,6 @@ def test_handle_path_file(mock_isdir, mock_isfile, mock_handle_directory, mock_h
 
     mock_handle_file_removal.assert_called_once_with("some/file.txt", 90)
     mock_handle_directory.assert_not_called()
-
 
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
@@ -59,7 +55,6 @@ def test_handle_directory_empty(tmp_path):
 
     assert not empty_dir.exists()
 
-
 def test_handle_directory_not_empty_all_exceed_retention(tmp_path):
     directory = tmp_path / "all_old"
     directory.mkdir()
@@ -72,7 +67,6 @@ def test_handle_directory_not_empty_all_exceed_retention(tmp_path):
     assert not old_file.exists()
     assert not directory.exists()
 
-
 def test_handle_directory_not_empty_all_within_retention(tmp_path):
     directory = tmp_path / "all_fresh"
     directory.mkdir()
@@ -84,7 +78,6 @@ def test_handle_directory_not_empty_all_within_retention(tmp_path):
 
     assert fresh_file.exists()
     assert directory.exists()
-
 
 def test_handle_directory_mixed_contents(tmp_path):
     directory = tmp_path / "mixed"
@@ -102,7 +95,6 @@ def test_handle_directory_mixed_contents(tmp_path):
     assert fresh_file.exists()
     assert directory.exists()
 
-
 def test_handle_directory_nested_recursive_cleanup(tmp_path):
     directory = tmp_path / "dir"
     subdir = directory / "subdir"
@@ -117,7 +109,6 @@ def test_handle_directory_nested_recursive_cleanup(tmp_path):
     assert not subdir.exists()
     assert not directory.exists()
 
-
 def test_handle_file_removal_exceeds_retention(tmp_path):
     file_path = tmp_path / "old.txt"
     file_path.write_text("old")
@@ -126,7 +117,6 @@ def test_handle_file_removal_exceeds_retention(tmp_path):
     folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
 
     assert not file_path.exists()
-
 
 def test_handle_file_removal_within_retention(tmp_path):
     file_path = tmp_path / "fresh.txt"
@@ -137,7 +127,6 @@ def test_handle_file_removal_within_retention(tmp_path):
 
     assert file_path.exists()
 
-
 def test_handle_file_removal_at_retention_boundary(tmp_path):
     file_path = tmp_path / "boundary.txt"
     file_path.write_text("boundary")
@@ -146,7 +135,6 @@ def test_handle_file_removal_at_retention_boundary(tmp_path):
     folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
 
     assert file_path.exists()
-
 
 def test_handle_file_removal_read_only(tmp_path):
     file_path = tmp_path / "readonly.txt"
@@ -157,7 +145,6 @@ def test_handle_file_removal_read_only(tmp_path):
     folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
 
     assert not file_path.exists()
-
 
 @patch("os.remove")
 def test_handle_file_removal_unrecoverable_error(mock_remove, tmp_path, capsys):
@@ -171,7 +158,6 @@ def test_handle_file_removal_unrecoverable_error(mock_remove, tmp_path, capsys):
     assert file_path.exists()
     assert "Could not remove file" in capsys.readouterr().out
 
-
 def test_handle_directory_removal_not_read_only(tmp_path):
     directory = tmp_path / "plain"
     directory.mkdir()
@@ -180,7 +166,6 @@ def test_handle_directory_removal_not_read_only(tmp_path):
     folder_cleanup.handle_directory_removal(str(directory))
 
     assert not directory.exists()
-
 
 def test_handle_directory_removal_read_only(tmp_path):
     directory = tmp_path / "readonly"
@@ -192,7 +177,6 @@ def test_handle_directory_removal_read_only(tmp_path):
     folder_cleanup.handle_directory_removal(str(directory))
 
     assert not directory.exists()
-
 
 @patch("shutil.rmtree")
 def test_handle_directory_removal_unrecoverable_error(mock_rmtree, tmp_path, capsys):
@@ -208,7 +192,6 @@ def test_handle_directory_removal_unrecoverable_error(mock_rmtree, tmp_path, cap
     assert directory.exists()
     assert "Could not remove directory or file" in capsys.readouterr().out
 
-
 def test_remove_readonly_eacces_retries(tmp_path):
     file_path = tmp_path / "readonly.txt"
     file_path.write_text("content")
@@ -218,7 +201,6 @@ def test_remove_readonly_eacces_retries(tmp_path):
     folder_cleanup.remove_readonly(os.remove, str(file_path), exc)
 
     assert not file_path.exists()
-
 
 def _age(path, days_old):
     timestamp = (datetime.now() - timedelta(days=days_old)).timestamp()

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -1,4 +1,5 @@
 import os
+import stat
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -142,6 +143,67 @@ def test_handle_file_removal_at_retention_boundary(tmp_path):
     folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
 
     assert file_path.exists()
+
+
+def test_handle_file_removal_read_only(tmp_path):
+    file_path = tmp_path / "readonly.txt"
+    file_path.write_text("content")
+    _age(file_path, RETENTION_DAYS + 1)
+    os.chmod(file_path, stat.S_IREAD)
+
+    folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
+
+    assert not file_path.exists()
+
+
+@patch("os.remove")
+def test_handle_file_removal_unrecoverable_error(mock_remove, tmp_path, capsys):
+    mock_remove.side_effect = OSError("Permission denied by ACL")
+    file_path = tmp_path / "locked.txt"
+    file_path.write_text("content")
+    _age(file_path, RETENTION_DAYS + 1)
+
+    folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
+
+    assert file_path.exists()
+    assert "Could not remove file" in capsys.readouterr().out
+
+
+def test_handle_directory_removal_not_read_only(tmp_path):
+    directory = tmp_path / "plain"
+    directory.mkdir()
+    (directory / "file.txt").write_text("content")
+
+    folder_cleanup.handle_directory_removal(str(directory))
+
+    assert not directory.exists()
+
+
+def test_handle_directory_removal_read_only(tmp_path):
+    directory = tmp_path / "readonly"
+    directory.mkdir()
+    read_only_file = directory / "file.txt"
+    read_only_file.write_text("content")
+    os.chmod(read_only_file, stat.S_IREAD)
+
+    folder_cleanup.handle_directory_removal(str(directory))
+
+    assert not directory.exists()
+
+
+@patch("shutil.rmtree")
+def test_handle_directory_removal_unrecoverable_error(mock_rmtree, tmp_path, capsys):
+    mock_rmtree.side_effect = OSError("Permission denied by ACL")
+    directory = tmp_path / "locked"
+    directory.mkdir()
+
+    folder_cleanup.handle_directory_removal(str(directory))
+
+    mock_rmtree.assert_called_once_with(
+        str(directory), ignore_errors=False, onerror=folder_cleanup.remove_readonly
+    )
+    assert directory.exists()
+    assert "Could not remove directory or file" in capsys.readouterr().out
 
 
 def _age(path, days_old):

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -119,6 +119,22 @@ def test_handle_path_neither_file_nor_dir(mock_isdir, mock_isfile, mock_handle_d
     mock_handle_directory.assert_not_called()
     mock_handle_file_removal.assert_not_called()
 
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+@patch("os.path.islink")
+def test_handle_path_symlink_is_ignored(mock_islink, mock_isdir, mock_isfile, mock_handle_directory, mock_handle_file_removal, capsys):
+    mock_islink.return_value = True
+    mock_isdir.return_value = True
+    mock_isfile.return_value = False
+
+    folder_cleanup.handle_path("some/symlink", 90)
+
+    mock_handle_directory.assert_not_called()
+    mock_handle_file_removal.assert_not_called()
+    assert "symbolic link" in capsys.readouterr().out
+
 def test_handle_directory_empty(tmp_path):
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+from xnat_maintenance_monitoring_scripts import folder_cleanup
+
+
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+def test_handle_path_dir(mock_isdir, mock_isfile, mock_handle_directory, mock_handle_file_removal):
+    mock_isdir.return_value = True
+    mock_isfile.return_value = False
+
+    folder_cleanup.handle_path("some/dir", 90)
+
+    mock_handle_directory.assert_called_once_with("some/dir", 90)
+    mock_handle_file_removal.assert_not_called()
+
+
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+def test_handle_path_file(mock_isdir, mock_isfile, mock_handle_directory, mock_handle_file_removal):
+    mock_isdir.return_value = False
+    mock_isfile.return_value = True
+
+    folder_cleanup.handle_path("some/file.txt", 90)
+
+    mock_handle_file_removal.assert_called_once_with("some/file.txt", 90)
+    mock_handle_directory.assert_not_called()
+
+
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
+@patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
+@patch("os.path.isfile")
+@patch("os.path.isdir")
+def test_handle_path_neither_file_nor_dir(mock_isdir, mock_isfile, mock_handle_directory, mock_handle_file_removal):
+    mock_isdir.return_value = False
+    mock_isfile.return_value = False
+
+    folder_cleanup.handle_path("broken/symlink", 90)
+
+    mock_handle_directory.assert_not_called()
+    mock_handle_file_removal.assert_not_called()

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -35,7 +35,7 @@ def test_cleanup_path_is_symlink(mock_islink, tmp_path, capsys):
     assert "path is a symbolic link" in capsys.readouterr().out
     assert directory.exists()
 
-def test_cleanup_removes_old_file_and_empty_directory(tmp_path):
+def test_cleanup_removes_old_file_but_keeps_fresh_empty_directory(tmp_path):
     directory = tmp_path / "dir"
     directory.mkdir()
 
@@ -46,6 +46,15 @@ def test_cleanup_removes_old_file_and_empty_directory(tmp_path):
     folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
 
     assert not old_file.exists()
+    assert directory.exists()
+
+def test_cleanup_removes_empty_directory_once_it_ages_past_retention(tmp_path):
+    directory = tmp_path / "aged_empty"
+    directory.mkdir()
+    _age(directory, RETENTION_DAYS + 10)
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
     assert not directory.exists()
 
 def test_cleanup_keeps_directory_with_fresh_file(tmp_path):
@@ -61,7 +70,7 @@ def test_cleanup_keeps_directory_with_fresh_file(tmp_path):
     assert fresh_file.exists()
     assert directory.exists()
 
-def test_cleanup_nested_directories_recursively_cleaned(tmp_path, capsys):
+def test_cleanup_recursively_removes_old_file_but_keeps_fresh_dirs(tmp_path, capsys):
     directory = tmp_path / "dir"
 
     subdir = directory / "subdir"
@@ -75,9 +84,20 @@ def test_cleanup_nested_directories_recursively_cleaned(tmp_path, capsys):
     out = capsys.readouterr().out
 
     assert not old_file.exists()
-    assert not subdir.exists()
-    assert not directory.exists()
+    assert subdir.exists()
+    assert directory.exists()
     assert f"Successfully cleaned up directory {directory}" in out
+
+def test_cleanup_removes_empty_subdir_once_it_ages_past_retention(tmp_path):
+    directory = tmp_path / "dir"
+    subdir = directory / "subdir"
+    subdir.mkdir(parents=True)
+    _age(subdir, RETENTION_DAYS + 10)
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
+    assert not subdir.exists()
+    assert directory.exists()
 
 
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
@@ -138,12 +158,21 @@ def test_handle_path_symlink_is_ignored(mock_islink, mock_isdir, mock_isfile, mo
 def test_handle_directory_empty(tmp_path):
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
+    _age(empty_dir, RETENTION_DAYS + 10)
 
     folder_cleanup.handle_directory(str(empty_dir), RETENTION_DAYS)
 
     assert not empty_dir.exists()
 
-def test_handle_directory_not_empty_all_exceed_retention(tmp_path):
+def test_handle_directory_empty_within_retention_kept(tmp_path):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    folder_cleanup.handle_directory(str(empty_dir), RETENTION_DAYS)
+
+    assert empty_dir.exists()
+
+def test_handle_directory_removes_old_file_but_keeps_fresh_empty_directory(tmp_path):
     directory = tmp_path / "all_old"
     directory.mkdir()
     old_file = directory / "old.txt"
@@ -153,7 +182,7 @@ def test_handle_directory_not_empty_all_exceed_retention(tmp_path):
     folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
 
     assert not old_file.exists()
-    assert not directory.exists()
+    assert directory.exists()
 
 def test_handle_directory_not_empty_all_within_retention(tmp_path):
     directory = tmp_path / "all_fresh"
@@ -183,7 +212,7 @@ def test_handle_directory_mixed_contents(tmp_path):
     assert fresh_file.exists()
     assert directory.exists()
 
-def test_handle_directory_nested_recursive_cleanup(tmp_path):
+def test_handle_directory_recursively_removes_old_file_but_keeps_fresh_dirs(tmp_path):
     directory = tmp_path / "dir"
     subdir = directory / "subdir"
     subdir.mkdir(parents=True)
@@ -194,8 +223,19 @@ def test_handle_directory_nested_recursive_cleanup(tmp_path):
     folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
 
     assert not old_file.exists()
+    assert subdir.exists()
+    assert directory.exists()
+
+def test_handle_directory_removes_empty_subdir_once_it_ages_past_retention(tmp_path):
+    directory = tmp_path / "dir"
+    subdir = directory / "subdir"
+    subdir.mkdir(parents=True)
+    _age(subdir, RETENTION_DAYS + 10)
+
+    folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
+
     assert not subdir.exists()
-    assert not directory.exists()
+    assert directory.exists()
 
 def test_handle_file_removal_exceeds_retention(tmp_path):
     file_path = tmp_path / "old.txt"
@@ -224,15 +264,7 @@ def test_handle_file_removal_at_retention_boundary(tmp_path):
 
     assert file_path.exists()
 
-def test_handle_file_removal_read_only(tmp_path):
-    file_path = tmp_path / "readonly.txt"
-    file_path.write_text("content")
-    _age(file_path, RETENTION_DAYS + 1)
-    os.chmod(file_path, stat.S_IREAD)
 
-    folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
-
-    assert not file_path.exists()
 
 @patch("os.remove")
 def test_handle_file_removal_unrecoverable_error(mock_remove, tmp_path, capsys):
@@ -246,49 +278,7 @@ def test_handle_file_removal_unrecoverable_error(mock_remove, tmp_path, capsys):
     assert file_path.exists()
     assert "Could not remove file" in capsys.readouterr().out
 
-def test_handle_directory_removal_not_read_only(tmp_path):
-    directory = tmp_path / "plain"
-    directory.mkdir()
-    (directory / "file.txt").write_text("content")
 
-    folder_cleanup.handle_directory_removal(str(directory))
-
-    assert not directory.exists()
-
-def test_handle_directory_removal_read_only(tmp_path):
-    directory = tmp_path / "readonly"
-    directory.mkdir()
-    read_only_file = directory / "file.txt"
-    read_only_file.write_text("content")
-    os.chmod(read_only_file, stat.S_IREAD)
-
-    folder_cleanup.handle_directory_removal(str(directory))
-
-    assert not directory.exists()
-
-@patch("shutil.rmtree")
-def test_handle_directory_removal_unrecoverable_error(mock_rmtree, tmp_path, capsys):
-    mock_rmtree.side_effect = OSError("Permission denied by ACL")
-    directory = tmp_path / "locked"
-    directory.mkdir()
-
-    folder_cleanup.handle_directory_removal(str(directory))
-
-    mock_rmtree.assert_called_once_with(
-        str(directory), ignore_errors=False, onerror=folder_cleanup.remove_readonly
-    )
-    assert directory.exists()
-    assert "Could not remove directory or file" in capsys.readouterr().out
-
-def test_remove_readonly_eacces_retries(tmp_path):
-    file_path = tmp_path / "readonly.txt"
-    file_path.write_text("content")
-    os.chmod(file_path, stat.S_IREAD)
-    exc = (OSError, OSError(errno.EACCES, "Access denied"), None)
-
-    folder_cleanup.remove_readonly(os.remove, str(file_path), exc)
-
-    assert not file_path.exists()
 
 def _age(path, days_old):
     timestamp = (datetime.now() - timedelta(days=days_old)).timestamp()

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -1,7 +1,10 @@
+import os
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from xnat_maintenance_monitoring_scripts import folder_cleanup
 
+RETENTION_DAYS = 90
 
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
@@ -43,3 +46,73 @@ def test_handle_path_neither_file_nor_dir(mock_isdir, mock_isfile, mock_handle_d
 
     mock_handle_directory.assert_not_called()
     mock_handle_file_removal.assert_not_called()
+
+def test_handle_directory_empty(tmp_path):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    folder_cleanup.handle_directory(str(empty_dir), RETENTION_DAYS)
+
+    assert not empty_dir.exists()
+
+
+def test_handle_directory_not_empty_all_exceed_retention(tmp_path):
+    directory = tmp_path / "all_old"
+    directory.mkdir()
+    old_file = directory / "old.txt"
+    old_file.write_text("old")
+    _age(old_file, RETENTION_DAYS + 10)
+
+    folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
+
+    assert not old_file.exists()
+    assert not directory.exists()
+
+
+def test_handle_directory_not_empty_all_within_retention(tmp_path):
+    directory = tmp_path / "all_fresh"
+    directory.mkdir()
+    fresh_file = directory / "fresh.txt"
+    fresh_file.write_text("fresh")
+    _age(fresh_file, RETENTION_DAYS - 10)
+
+    folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
+
+    assert fresh_file.exists()
+    assert directory.exists()
+
+
+def test_handle_directory_mixed_contents(tmp_path):
+    directory = tmp_path / "mixed"
+    directory.mkdir()
+    old_file = directory / "old.txt"
+    fresh_file = directory / "fresh.txt"
+    old_file.write_text("old")
+    fresh_file.write_text("fresh")
+    _age(old_file, RETENTION_DAYS + 10)
+    _age(fresh_file, RETENTION_DAYS - 10)
+
+    folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
+
+    assert not old_file.exists()
+    assert fresh_file.exists()
+    assert directory.exists()
+
+
+def test_handle_directory_nested_recursive_cleanup(tmp_path):
+    directory = tmp_path / "dir"
+    subdir = directory / "subdir"
+    subdir.mkdir(parents=True)
+    old_file = subdir / "file.txt"
+    old_file.write_text("old")
+    _age(old_file, RETENTION_DAYS + 10)
+
+    folder_cleanup.handle_directory(str(directory), RETENTION_DAYS)
+
+    assert not old_file.exists()
+    assert not subdir.exists()
+    assert not directory.exists()
+
+def _age(path, days_old):
+    timestamp = (datetime.now() - timedelta(days=days_old)).timestamp()
+    os.utime(path, (timestamp, timestamp))

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -113,6 +113,37 @@ def test_handle_directory_nested_recursive_cleanup(tmp_path):
     assert not subdir.exists()
     assert not directory.exists()
 
+
+def test_handle_file_removal_exceeds_retention(tmp_path):
+    file_path = tmp_path / "old.txt"
+    file_path.write_text("old")
+    _age(file_path, RETENTION_DAYS + 1)
+
+    folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
+
+    assert not file_path.exists()
+
+
+def test_handle_file_removal_within_retention(tmp_path):
+    file_path = tmp_path / "fresh.txt"
+    file_path.write_text("fresh")
+    _age(file_path, RETENTION_DAYS - 10)
+
+    folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
+
+    assert file_path.exists()
+
+
+def test_handle_file_removal_at_retention_boundary(tmp_path):
+    file_path = tmp_path / "boundary.txt"
+    file_path.write_text("boundary")
+    _age(file_path, RETENTION_DAYS)
+
+    folder_cleanup.handle_file_removal(str(file_path), RETENTION_DAYS)
+
+    assert file_path.exists()
+
+
 def _age(path, days_old):
     timestamp = (datetime.now() - timedelta(days=days_old)).timestamp()
     os.utime(path, (timestamp, timestamp))

--- a/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
+++ b/tests/xnat_maintenance_monitoring_scripts/test_folder_cleanup.py
@@ -8,6 +8,84 @@ from xnat_maintenance_monitoring_scripts import folder_cleanup
 
 RETENTION_DAYS = 90
 
+def test_cleanup_path_does_not_exist(tmp_path, capsys):
+    missing_path = tmp_path / "missing"
+
+    folder_cleanup.cleanup(str(missing_path), RETENTION_DAYS)
+
+    assert "path does not exist" in capsys.readouterr().out
+
+def test_cleanup_path_not_a_directory(tmp_path, capsys):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content")
+
+    folder_cleanup.cleanup(str(file_path), RETENTION_DAYS)
+
+    assert "path is not a directory" in capsys.readouterr().out
+    assert file_path.exists()
+
+@patch("os.path.islink")
+def test_cleanup_path_is_symlink(mock_islink, tmp_path, capsys):
+    mock_islink.return_value = True
+    directory = tmp_path / "link_dir"
+    directory.mkdir()
+    (directory / "file.txt").write_text("content")
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
+    assert (directory / "file.txt").exists()
+    assert "path is a symbolic link" in capsys.readouterr().out
+
+def test_cleanup_removes_old_file_and_empty_directory(tmp_path):
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    old_file = directory / "old.txt"
+    old_file.write_text("old")
+    _age(old_file, RETENTION_DAYS + 10)
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
+    assert not old_file.exists()
+    assert not directory.exists()
+
+def test_cleanup_keeps_directory_with_fresh_file(tmp_path):
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    fresh_file = directory / "fresh.txt"
+    fresh_file.write_text("fresh")
+    _age(fresh_file, RETENTION_DAYS - 10)
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
+    assert fresh_file.exists()
+    assert directory.exists()
+
+def test_cleanup_nested_directories_recursively_cleaned(tmp_path):
+    directory = tmp_path / "dir"
+    subdir = directory / "subdir"
+    subdir.mkdir(parents=True)
+    old_file = subdir / "old.txt"
+    old_file.write_text("old")
+    _age(old_file, RETENTION_DAYS + 10)
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
+    assert not old_file.exists()
+    assert not subdir.exists()
+    assert not directory.exists()
+
+def test_cleanup_prints_success_message(tmp_path, capsys):
+    directory = tmp_path / "dir"
+    directory.mkdir()
+    fresh_file = directory / "fresh.txt"
+    fresh_file.write_text("fresh")
+    _age(fresh_file, RETENTION_DAYS - 10)
+
+    folder_cleanup.cleanup(str(directory), RETENTION_DAYS)
+
+    out = capsys.readouterr().out
+    assert f"Successfully cleaned up directory {directory}" in out
+
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_file_removal")
 @patch("xnat_maintenance_monitoring_scripts.folder_cleanup.handle_directory")
 @patch("os.path.isfile")


### PR DESCRIPTION
## Summary

Adds a `folder_cleanup.py` script for removing old files/folders from a provided path (e.g. cache, temp, deleted) based on a retention period provided.

- Recursively walks a target directory (`--dir_path`) and removes files whose last-modified time exceeds `--retention_days` (default: 90)
- After clearing old files, removes any directories left empty as a result, including the target directory itself if it ends up empty
- Handles Windows/OneDrive read-only file attributes that would otherwise cause `EACCES` errorsthe attribute and retrying
- Non-readonly removal errors (e.g. ACL delete-deny) are re-raised

## Test plan

- [x] Unit tests for `handle_path`, `handle_directory`, `handle_file_removal`, and readonly-file/directory removal (`tests/test_folder_cleanup.py`)